### PR TITLE
fix: migrate scan.py from bluepy to bleak

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -1,20 +1,13 @@
 #!/usr/bin/env python3
-from bluepy.btle import Scanner, DefaultDelegate
+import asyncio
+from bleak import BleakScanner
 
-class ScanDelegate(DefaultDelegate):
-	def __init__(self):
-		DefaultDelegate.__init__(self)
 
-	def handleDiscovery(self, dev, isNewDev, isNewData):
-		if isNewDev:
-			print( "Discovered device ", dev.addr)
-		elif isNewData:
-			print( "Received new data from ", dev.addr)
+async def main():
+    print("Scanning for 10 seconds...")
+    devices = await BleakScanner.discover(timeout=10.0)
+    for dev in sorted(devices, key=lambda d: d.rssi, reverse=True):
+        print(f"Device {dev.address}, RSSI={dev.rssi} dB, Name={dev.name or '(unknown)'}")
 
-scanner = Scanner().withDelegate(ScanDelegate())
-devices = scanner.scan(10.0)
 
-for dev in devices:
-	print( "Device %s (%s), RSSI=%d dB" % (dev.addr, dev.addrType, dev.rssi) )
-	for (adtype, desc, value) in dev.getScanData():
-		print( "  %s = %s" % (desc, value) )
+asyncio.run(main())


### PR DESCRIPTION
## Summary
- Removes the last remaining `bluepy` import from the codebase
- Rewrites `scan.py` using `bleak` (async, pure Python) to match the rest of the driver
- Sorts discovered devices by RSSI descending for easier readability

Closes #9

## Test plan
- [ ] Run `./scan.py` on VenusOS device — should list nearby BLE devices without error
- [ ] Confirm battery MAC addresses appear in output

🤖 Generated with [Claude Code](https://claude.com/claude-code)