### PR TITLE
fix: DBusGMainLoop ordering and CONNECTION_MODE config resolution

### DIFF
--- a/dbus-btbattery.py
+++ b/dbus-btbattery.py
@@ -22,6 +22,9 @@ logger.info("Starting dbus-btbattery")
 
 
 def main():
+	# Must be called before any D-Bus connections are made
+	DBusGMainLoop(set_as_default=True)
+
 	logger.info(
 		"dbus-btbattery v" + str(utils.DRIVER_VERSION) + utils.DRIVER_SUBVERSION
 	)
@@ -75,7 +78,6 @@ def main():
 		helpers.append(DbusHelper(batt))
 		logger.info("Single battery mode")
 
-	DBusGMainLoop(set_as_default=True)
 	mainloop = gobject.MainLoop()
 
 	for helper in helpers:

--- a/dbus_btbattery_cli.py
+++ b/dbus_btbattery_cli.py
@@ -29,15 +29,17 @@ def parse_args():
 	if not args.addresses and utils.BT_ADDRESSES:
 		args.addresses = utils.BT_ADDRESSES
 
-	# Resolve mode
+	# Resolve mode: CLI flags > config.ini > legacy fallback
 	if args.parallel:
 		args.mode = 'parallel'
 	elif args.series:
 		args.mode = 'series'
+	elif utils.CONNECTION_MODE in ('parallel', 'series'):
+		args.mode = utils.CONNECTION_MODE
 	elif len(args.addresses) > 1:
-		args.mode = 'series'  # legacy backwards compat
+		args.mode = 'series'  # legacy: multiple addresses without flag
 	else:
-		args.mode = utils.CONNECTION_MODE if utils.CONNECTION_MODE != 'single' else 'single'
+		args.mode = 'single'
 
 	# Resolve timing: CLI overrides config.ini
 	if args.bt_poll_interval is None:


### PR DESCRIPTION
## Summary
- Moves `DBusGMainLoop(set_as_default=True)` to top of `main()` before any D-Bus connections are made — fixes startup `RuntimeError`
- Fixes `CONNECTION_MODE` in `config.ini` being ignored when `BT_ADDRESSES` is also set — config addresses triggered the legacy multi-address series fallback before the mode was checked

Closes #12
Closes #13

## Test plan
- [ ] Run `./dbus-btbattery.py` with `CONNECTION_MODE=parallel` and `BT_ADDRESSES` in `config.ini` — should start in parallel mode, not series
- [ ] Verify no D-Bus `RuntimeError` on startup
- [ ] Verify 5 D-Bus services register (4 individual + 1 aggregate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)