### PR TITLE
fix: serialize BLE connect phase to prevent BlueZ InProgress errors

### DIFF
--- a/dbus-btbattery.py
+++ b/dbus-btbattery.py
@@ -4,7 +4,6 @@
 from dbus.mainloop.glib import DBusGMainLoop
 from threading import Thread
 import sys
-import time
 
 from gi.repository import GLib as gobject
 
@@ -45,13 +44,9 @@ def main():
 	jbdbt.BT_POLL_INTERVAL = args.bt_poll_interval
 	jbdbt.BT_WATCHDOG_TIMER = args.bt_watchdog_timer
 
-	# Create JbdBt instances with a stagger between each to avoid
-	# overwhelming the BT adapter with simultaneous connection attempts
-	batteries = []
-	for i, addr in enumerate(args.addresses):
-		batteries.append(JbdBt(addr))
-		if i < len(args.addresses) - 1:
-			time.sleep(3)
+	# Create JbdBt instances — BLE connections are serialized via asyncio
+	# lock in jbdbt.py to avoid BlueZ InProgress errors
+	batteries = [JbdBt(addr) for addr in args.addresses]
 
 	helpers = []
 

--- a/dbushelper.py
+++ b/dbushelper.py
@@ -20,10 +20,13 @@ from utils import *
 
 
 def get_bus():
+    # private=True creates a new connection each call; the default singleton
+    # connection causes KeyError when multiple VeDbusService instances each
+    # try to register the root '/' object-path handler on the same connection.
     return (
-        dbus.SessionBus()
+        dbus.SessionBus(private=True)
         if "DBUS_SESSION_BUS_ADDRESS" in os.environ
-        else dbus.SystemBus()
+        else dbus.SystemBus(private=True)
     )
 
 

--- a/jbdbt.py
+++ b/jbdbt.py
@@ -65,12 +65,18 @@ class JbdProtection(Protection):
 _ble_loop: asyncio.AbstractEventLoop | None = None
 _ble_loop_lock = threading.Lock()
 
+# Serializes BLE connect/scan operations: BlueZ only allows one active
+# discovery at a time, so concurrent connect() calls fail with InProgress.
+# Released once connected; polling runs concurrently without the lock.
+_ble_connect_lock: asyncio.Lock | None = None
+
 
 def _get_ble_loop() -> asyncio.AbstractEventLoop:
-	global _ble_loop
+	global _ble_loop, _ble_connect_lock
 	with _ble_loop_lock:
 		if _ble_loop is None or not _ble_loop.is_running():
 			_ble_loop = asyncio.new_event_loop()
+			_ble_connect_lock = asyncio.Lock()
 			t = threading.Thread(target=_ble_loop.run_forever, daemon=True)
 			t.start()
 		return _ble_loop
@@ -106,24 +112,31 @@ class BleakJbdDev:
 
 	async def _ble_main_loop(self):
 		while self.running:
+			client = BleakClient(self.address)
 			try:
 				logger.info('Connecting ' + self.address)
-				async with BleakClient(self.address) as client:
-					logger.info('Connected ' + self.address)
-					self.reset()
+				# Serialize the connect/scan phase — BlueZ allows only one
+				# active discovery at a time. Lock is released once connected
+				# so other batteries can connect while this one polls.
+				async with _ble_connect_lock:
+					await client.connect()
 
-					await client.start_notify(BLE_RX_UUID, self._notification_handler)
+				logger.info('Connected ' + self.address)
+				self.reset()
+				await client.start_notify(BLE_RX_UUID, self._notification_handler)
 
-					while self.running and client.is_connected:
-						await client.write_gatt_char(BLE_TX_UUID, CMD_GENERAL_INFO, response=True)
-						await asyncio.sleep(0.5)
-						await client.write_gatt_char(BLE_TX_UUID, CMD_CELL_VOLTAGES, response=True)
-						await asyncio.sleep(self.interval)
+				while self.running and client.is_connected:
+					await client.write_gatt_char(BLE_TX_UUID, CMD_GENERAL_INFO, response=True)
+					await asyncio.sleep(0.5)
+					await client.write_gatt_char(BLE_TX_UUID, CMD_CELL_VOLTAGES, response=True)
+					await asyncio.sleep(self.interval)
 
 			except BleakError as ex:
 				logger.info('Connection failed: ' + str(ex))
 			except Exception as ex:
 				logger.info('BLE error: ' + str(ex))
+			finally:
+				await client.disconnect()
 
 			if self.running:
 				logger.info('Disconnected')


### PR DESCRIPTION
## Summary
- Adds shared `asyncio.Lock` to serialize BLE connect/scan phase — BlueZ only allows one active discovery at a time; concurrent `connect()` calls fail with `InProgress`. Lock is released once connected so all batteries poll concurrently.
- Uses `dbus.SystemBus(private=True)` so each `VeDbusService` gets its own connection — the default singleton connection causes `KeyError` when multiple services each try to register the root `/` path handler.
- Removes now-unnecessary `time.sleep` stagger from `main()`.

Closes #15
Closes #17

## Test plan
- [ ] Run `./dbus-btbattery.py` in parallel mode — all 4 batteries should connect without `InProgress` errors
- [ ] Verify 5 D-Bus services register (4 individual + 1 aggregate) without `KeyError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)