### PR TITLE
fix: pin bleak <3.0.0 and remove hardcoded addresses from service/run

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-bleak>=0.21.0
+bleak>=0.21.0,<3.0.0
 dbus-python>=1.3.2
 PyGObject>=3.42.0

--- a/service/run
+++ b/service/run
@@ -3,6 +3,6 @@ exec 2>&1
 # Single battery:
 # exec /opt/victronenergy/dbus-btbattery/dbus-btbattery.py 70:3e:97:08:00:62
 # Parallel batteries:
-exec /opt/victronenergy/dbus-btbattery/dbus-btbattery.py --parallel 70:3e:97:08:00:62 a4:c1:37:40:89:5e a4:c1:37:00:25:91 a4:c1:37:00:25:92
+exec /opt/victronenergy/dbus-btbattery/dbus-btbattery.py
 # Series batteries:
 # exec /opt/victronenergy/dbus-btbattery/dbus-btbattery.py --series 70:3e:97:08:00:62 a4:c1:37:40:89:5e


### PR DESCRIPTION
## Summary
- Pin `bleak>=0.21.0,<3.0.0` — bleak 3.0 hangs on `client.connect()` on Venus OS, blocking all D-Bus registration
- Remove placeholder MAC addresses from `service/run` so connection config is read from `config.ini`

## Test plan
- [ ] Verify `pip3 install -r requirements.txt` installs bleak 0.22.x not 3.x
- [ ] Confirm `service/run` starts driver with no CLI addresses (reads from config.ini)
- [ ] Confirm all batteries connect and D-Bus services register on Cerbo GX

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)