### PR TITLE
fix: error handling hardening — 10 HIGH/MEDIUM issues across 7 files

### DIFF
--- a/battery.py
+++ b/battery.py
@@ -274,6 +274,7 @@ class Battery(ABC):
                 False,
             )
         except Exception:
+            logger.warning("calcMaxChargeCurrentReferringToCellVoltage failed for %s", self.port, exc_info=True)
             return self.max_battery_charge_current
 
     def calcMaxDischargeCurrentReferringToCellVoltage(self) -> float:
@@ -291,7 +292,8 @@ class Battery(ABC):
                 True,
             )
         except Exception:
-            return self.max_battery_charge_current
+            logger.warning("calcMaxDischargeCurrentReferringToCellVoltage failed for %s", self.port, exc_info=True)
+            return self.max_battery_discharge_current
 
     def calcMaxChargeCurrentReferringToTemperature(self) -> float:
         if self.get_max_temp() is None:
@@ -362,6 +364,7 @@ class Battery(ABC):
                 self.soc, SOC_WHILE_CHARGING, MAX_CHARGE_CURRENT_SOC, True
             )
         except Exception:
+            logger.warning("calcMaxChargeCurrentReferringToSoc failed for %s", self.port, exc_info=True)
             return self.max_battery_charge_current
 
     def calcMaxDischargeCurrentReferringToSoc(self) -> float:
@@ -386,7 +389,8 @@ class Battery(ABC):
                 self.soc, SOC_WHILE_DISCHARGING, MAX_DISCHARGE_CURRENT_SOC, True
             )
         except Exception:
-            return self.max_battery_charge_current
+            logger.warning("calcMaxDischargeCurrentReferringToSoc failed for %s", self.port, exc_info=True)
+            return self.max_battery_discharge_current
 
     def get_min_cell(self) -> int:
         min_voltage = 9999

--- a/dbus-btbattery.py
+++ b/dbus-btbattery.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 from dbus.mainloop.glib import DBusGMainLoop
-from threading import Thread
 import sys
 
 from gi.repository import GLib as gobject
@@ -42,9 +41,12 @@ def main():
 	# which copies at import time, so the module-level var must be set directly.
 	jbdbt.BT_POLL_INTERVAL = args.bt_poll_interval
 
-	# Create JbdBt instances — BLE connects are serialized via asyncio
-	# lock in jbdbt.py to avoid BlueZ InProgress errors
-	batteries = [JbdBt(addr) for addr in args.addresses]
+	# Create JbdBt instances with staggered initial delays so batteries
+	# connect at evenly spaced intervals rather than all at once.
+	batteries = [
+		JbdBt(addr, initial_delay=i * utils.BT_CONNECT_STAGGER)
+		for i, addr in enumerate(args.addresses)
+	]
 
 	helpers = []
 
@@ -73,17 +75,60 @@ def main():
 
 	mainloop = gobject.MainLoop()
 
+	active_helpers = []
+	pending = []  # list of [JbdBt_instance, retry_count]
+
 	for helper in helpers:
-		if not helper.setup_vedbus():
-			logger.error("ERROR >>> Problem setting up vedbus for " + str(helper.battery.port))
-			sys.exit(1)
+		if helper.setup_vedbus():
+			active_helpers.append(helper)
+		else:
+			logger.warning(
+				"Battery %s failed initial setup, will retry every %ds (max %d retries, 0=indefinite)",
+				helper.battery.port,
+				utils.BT_INIT_RETRY_INTERVAL,
+				utils.BT_INIT_MAX_RETRIES,
+			)
+			pending.append([helper.battery, 0])
 
 	def poll_all_batteries(loop):
-		for helper in helpers:
-			poller = Thread(target=lambda h=helper: h.publish_battery(loop))
-			poller.daemon = True
-			poller.start()
+		for helper in active_helpers:
+			try:
+				helper.publish_battery(loop)
+			except Exception:
+				logger.error(
+					"Unhandled exception in publish_battery for %s",
+					helper.battery.port,
+					exc_info=True,
+				)
 		return True
+
+	if pending:
+		def retry_pending():
+			still_pending = []
+			for batt, retry_count in pending:
+				new_helper = DbusHelper(batt)
+				if new_helper.setup_vedbus():
+					active_helpers.append(new_helper)
+					logger.info(
+						"Battery %s registered after %d retries",
+						batt.port,
+						retry_count + 1,
+					)
+				else:
+					retry_count += 1
+					if utils.BT_INIT_MAX_RETRIES > 0 and retry_count >= utils.BT_INIT_MAX_RETRIES:
+						logger.error(
+							"Battery %s: giving up after %d retries",
+							batt.port,
+							retry_count,
+						)
+					else:
+						still_pending.append([batt, retry_count])
+			pending.clear()
+			pending.extend(still_pending)
+			return len(pending) > 0  # False stops the GLib timer
+
+		gobject.timeout_add(utils.BT_INIT_RETRY_INTERVAL * 1000, retry_pending)
 
 	gobject.timeout_add(args.dbus_poll_interval, lambda: poll_all_batteries(mainloop))
 	try:

--- a/dbushelper.py
+++ b/dbushelper.py
@@ -3,7 +3,6 @@ import sys
 import os
 import platform
 import dbus
-import traceback
 
 # Victron packages
 sys.path.insert(
@@ -84,8 +83,13 @@ class DbusHelper:
             # 'CCMCurrentLimitDischarge3': [path + '/CCMCurrentLimitDischarge3', '', 0, 100],
         }
 
-        self.settings = SettingsDevice(get_bus(), settings, self.handle_changed_setting)
+        try:
+            self.settings = SettingsDevice(get_bus(), settings, self.handle_changed_setting)
+        except Exception:
+            logger.error("SettingsDevice init failed for %s", self.battery.port, exc_info=True)
+            return False
         self.battery.role, self.instance = self.get_role_instance()
+        return True
 
     def get_role_instance(self):
         val = self.settings["instance"].split(":")
@@ -106,7 +110,8 @@ class DbusHelper:
         # Set up dbus service and device instance
         # and notify of all the attributes we intend to update
         # This is only called once when a battery is initiated
-        self.setup_instance()
+        if not self.setup_instance():
+            return False
         short_port = self.battery.port[self.battery.port.rfind("/") + 1 :]
         logger.info("%s" % ("com.victronenergy.battery." + short_port))
 
@@ -342,8 +347,16 @@ class DbusHelper:
                     loop.quit()
 
         except Exception:
-            traceback.print_exc()
-            loop.quit()
+            logger.error("Exception in publish_battery for %s", self.battery.port, exc_info=True)
+            self.error_count += 1
+            if self.error_count >= 10 and self.battery.online:
+                self.battery.online = False
+                try:
+                    self.publish_dbus()
+                except Exception:
+                    logger.warning("Could not publish offline status for %s", self.battery.port)
+            if self.error_count >= 60:
+                loop.quit()
 
     def publish_dbus(self):
 
@@ -474,8 +487,8 @@ class DbusHelper:
                     self.battery.get_max_cell_voltage()
                     - self.battery.get_min_cell_voltage()
                 )
-            except:
-                pass
+            except Exception:
+                logger.warning("Cell voltage publish failed for %s", self.battery.port, exc_info=True)
 
         # Update TimeToSoC
         try:
@@ -495,7 +508,7 @@ class DbusHelper:
                         if self.battery.current
                         else None
                     )
-                
+
                 # Update TimeToGo
                 self._dbusservice["/TimeToGo"] = (
                     self.battery.get_timetosoc(SOC_LOW_WARNING, crntPrctPerSec)
@@ -505,8 +518,8 @@ class DbusHelper:
 
             else:
                 self.battery.time_to_soc_update -= 1
-        except:
-            pass
+        except Exception:
+            logger.warning("TimeToSoC update failed for %s", self.battery.port, exc_info=True)
 
         logger.debug("logged to dbus [%s]" % str(round(self.battery.soc, 2)))
         self.battery.log_cell_data()

--- a/default_config.ini
+++ b/default_config.ini
@@ -149,6 +149,11 @@ BT_ADDRESSES =
 ; Each poll does a full connect → read → disconnect cycle.
 BT_POLL_INTERVAL = 300
 
+; Stagger initial BLE connections by this many seconds per battery index.
+; Battery 0 connects immediately; battery N waits N * BT_CONNECT_STAGGER seconds.
+; Keeps the fixed polling offset stable across all subsequent cycles.
+BT_CONNECT_STAGGER = 5
+
 ; Soft-reset timeout in seconds — resets notification handler state machine
 ; when no successful data callback has arrived within this window.
 ; 0 to disable. Must be > BT_POLL_INTERVAL.
@@ -161,3 +166,9 @@ BT_RECONNECT_TIMEOUT = 120
 
 ; D-Bus publish interval in milliseconds (how often cached data is pushed to D-Bus)
 DBUS_POLL_INTERVAL = 5000
+
+; Seconds between setup retries for batteries that fail initial connection
+BT_INIT_RETRY_INTERVAL = 30
+
+; Max setup retries before giving up; 0 = retry indefinitely
+BT_INIT_MAX_RETRIES = 5

--- a/jbdbt.py
+++ b/jbdbt.py
@@ -99,6 +99,7 @@ class BleakJbdDev:
 
 		self.address = address
 		self.interval = BT_POLL_INTERVAL
+		self.initial_delay = 0
 		self.running = False
 
 		# Set at the start of each read cycle; fired by the notification handler
@@ -119,9 +120,17 @@ class BleakJbdDev:
 
 	def connect(self):
 		self.running = True
-		asyncio.run_coroutine_threadsafe(self._ble_main_loop(), _get_ble_loop())
+		future = asyncio.run_coroutine_threadsafe(self._ble_main_loop(), _get_ble_loop())
+
+		def _on_ble_done(f):
+			if not f.cancelled() and f.exception():
+				logger.error("BLE loop for %s crashed: %s", self.address, f.exception())
+
+		future.add_done_callback(_on_ble_done)
 
 	async def _ble_main_loop(self):
+		if self.initial_delay > 0:
+			await asyncio.sleep(self.initial_delay)
 		while self.running:
 			success = False
 			client = BleakClient(self.address)
@@ -265,7 +274,7 @@ class BleakJbdDev:
 				self._general_event.set()
 
 class JbdBt(Battery):
-	def __init__(self, address):
+	def __init__(self, address, initial_delay=0):
 		Battery.__init__(self, 0, 0, address)
 
 		self.protection = JbdProtection()
@@ -280,6 +289,7 @@ class JbdBt(Battery):
 		self.interval = BT_POLL_INTERVAL
 
 		dev = BleakJbdDev(self.address)
+		dev.initial_delay = initial_delay
 		dev.addCellDataCallback(self.cellDataCB)
 		dev.addGeneralDataCallback(self.generalDataCB)
 		dev.connect()
@@ -290,10 +300,17 @@ class JbdBt(Battery):
 		return False
 
 	def get_settings(self):
+		deadline = time.monotonic() + BT_INIT_RETRY_INTERVAL
 		result = self.read_gen_data()
 		while not result:
-			result = self.read_gen_data()
+			if time.monotonic() >= deadline:
+				logger.warning(
+					"get_settings() timed out for %s — battery not available at startup",
+					self.address,
+				)
+				return False
 			time.sleep(1)
+			result = self.read_gen_data()
 		self.max_battery_charge_current = MAX_BATTERY_CHARGE_CURRENT
 		self.max_battery_discharge_current = MAX_BATTERY_DISCHARGE_CURRENT
 		return result
@@ -416,6 +433,11 @@ class JbdBt(Battery):
 				if len(cell_volts) != 0:
 					self.cells[c].voltage = cell_volts[0] / 1000
 			except error:
+				logger.warning(
+					"Cell %d voltage unpack failed for %s, setting to 0",
+					c,
+					self.address,
+				)
 				self.cells[c].voltage = 0
 
 		return True

--- a/parallel.py
+++ b/parallel.py
@@ -125,7 +125,13 @@ class ParallelBattery(Battery):
 
 	def refresh_data(self):
 		# Refresh each sub-battery first
-		refresh_results = [b.refresh_data() for b in self.batts]
+		refresh_results = []
+		for b in self.batts:
+			try:
+				refresh_results.append(b.refresh_data())
+			except Exception:
+				logger.error("refresh_data() failed for %s", b.port, exc_info=True)
+				refresh_results.append(False)
 		any_refreshed = any(refresh_results)
 
 		# Then aggregate the now-fresh data

--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -1,0 +1,38 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import utils
+import battery
+
+
+class _MockBattery(battery.Battery):
+    def test_connection(self): return True
+    def get_settings(self): return True
+    def refresh_data(self): return True
+
+
+def _make_battery():
+    b = _MockBattery("/bttest", 0, "test")
+    b.max_battery_charge_current = 70.0
+    b.max_battery_discharge_current = 90.0
+    b.soc = 50
+    return b
+
+
+def _raise(*args, **kwargs):
+    raise ValueError("injected error")
+
+
+def test_discharge_cv_returns_discharge_current_on_error(monkeypatch):
+    b = _make_battery()
+    monkeypatch.setattr(utils, "calcStepRelationship", _raise)
+    monkeypatch.setattr(utils, "calcLinearRelationship", _raise)
+    result = b.calcMaxDischargeCurrentReferringToCellVoltage()
+    assert result == 90.0, f"Expected 90.0 (discharge), got {result}"
+
+
+def test_discharge_soc_returns_discharge_current_on_error(monkeypatch):
+    b = _make_battery()
+    monkeypatch.setattr(utils, "calcStepRelationship", _raise)
+    monkeypatch.setattr(utils, "calcLinearRelationship", _raise)
+    result = b.calcMaxDischargeCurrentReferringToSoc()
+    assert result == 90.0, f"Expected 90.0 (discharge), got {result}"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,16 @@
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from utils import mapRange
+
+
+def test_mapRange_normal():
+    assert mapRange(5, 0, 10, 0, 100) == 50.0
+
+
+def test_mapRange_equal_bounds_returns_outMin_zero():
+    # Without the guard this raises ZeroDivisionError
+    assert mapRange(5, 3, 3, 0, 100) == 0
+
+
+def test_mapRange_equal_bounds_returns_outMin_nonzero():
+    assert mapRange(5, 3, 3, 40, 100) == 40

--- a/utils.py
+++ b/utils.py
@@ -225,7 +225,10 @@ BMS_TYPE = config["DEFAULT"]["BMS_TYPE"]
 CONNECTION_MODE = config["DEFAULT"]["CONNECTION_MODE"]
 BT_ADDRESSES = _get_list_from_config("DEFAULT", "BT_ADDRESSES")
 BT_POLL_INTERVAL = int(config["DEFAULT"]["BT_POLL_INTERVAL"])
+BT_CONNECT_STAGGER = int(config["DEFAULT"]["BT_CONNECT_STAGGER"])
 DBUS_POLL_INTERVAL = int(config["DEFAULT"]["DBUS_POLL_INTERVAL"])
+BT_INIT_RETRY_INTERVAL = int(config["DEFAULT"]["BT_INIT_RETRY_INTERVAL"])
+BT_INIT_MAX_RETRIES = int(config["DEFAULT"]["BT_INIT_MAX_RETRIES"])
 
 
 def constrain(val, min_val, max_val):
@@ -235,6 +238,8 @@ def constrain(val, min_val, max_val):
 
 
 def mapRange(inValue, inMin, inMax, outMin, outMax):
+    if inMax == inMin:
+        return outMin
     return outMin + (((inValue - inMin) / (inMax - inMin)) * (outMax - outMin))
 
 


### PR DESCRIPTION
## Summary

- **Fix dbus loop dying silently** (root cause: threading unsafety): route all `publish_battery` calls through the GLib main loop thread; add exception guard so one battery's failure doesn't kill the timer for all others
- **Fix stale data with no log evidence**: replace bare `except: pass` blocks with `logger.warning`; add `exc_info=True` throughout so failures leave a traceback
- **Fix startup blocking forever**: `get_settings()` now times out after `BT_INIT_RETRY_INTERVAL` (default 30 s) if BLE data never arrives; failed batteries are retried via a GLib timer instead of calling `sys.exit(1)`
- **Fix wrong return variable**: `calcMaxDischargeCurrentReferringToCellVoltage` and `calcMaxDischargeCurrentReferringToSoc` were returning `max_battery_charge_current` on exception — now correctly return `max_battery_discharge_current`
- **Fix parallel mode fragility**: per-battery `try/except` in `refresh_data()` so one battery exception can't abort the entire refresh
- **Fix `mapRange()` division by zero**: returns `outMin` when `inMax == inMin` (duplicate temperature boundary values in config no longer crash the publish loop)
- **Add BLE loop crash detection**: done-callback on the asyncio Future logs any unhandled exception that kills `_ble_main_loop`
- **Add startup connection stagger**: configurable per-battery initial delay (`BT_CONNECT_STAGGER`, default 5 s) to prevent simultaneous BlueZ connects

New config keys (all in `default_config.ini`, overridable in `config.ini`):

| Key | Default | Description |
|---|---|---|
| `BT_INIT_RETRY_INTERVAL` | `30` | Seconds between setup retries for batteries offline at boot |
| `BT_INIT_MAX_RETRIES` | `5` | Max retries before giving up; `0` = indefinitely |
| `BT_CONNECT_STAGGER` | `5` | Seconds between staggered BLE connection starts |

## Test Plan

- [ ] Deploy to Cerbo GX; confirm all 4 batteries register on D-Bus at startup
- [ ] Power off one battery before starting service; confirm warning log and retry every 30 s; confirm registration once powered on
- [ ] Monitor logs for 24 h; confirm no stale data and no silent timer death
- [ ] Verify `dbus -y com.victronenergy.battery.bt<addr> /Dc/0/Temperature GetValue` returns fresh values across all 4 batteries

Closes #32

🤖 Generated with [Claude Code](https://claude.ai/claude-code)