### PR TITLE
fix: guard None cell voltage before CCCM/DCCM calc and cell diff publish

### DIFF
--- a/battery.py
+++ b/battery.py
@@ -260,6 +260,8 @@ class Battery(ABC):
             self.control_allow_discharge = True
 
     def calcMaxChargeCurrentReferringToCellVoltage(self) -> float:
+        if self.get_max_cell_voltage() is None:
+            return self.max_battery_charge_current
         try:
             if utils.LINEAR_LIMITATION_ENABLE:
                 return utils.calcLinearRelationship(
@@ -278,6 +280,8 @@ class Battery(ABC):
             return self.max_battery_charge_current
 
     def calcMaxDischargeCurrentReferringToCellVoltage(self) -> float:
+        if self.get_min_cell_voltage() is None:
+            return self.max_battery_discharge_current
         try:
             if utils.LINEAR_LIMITATION_ENABLE:
                 return utils.calcLinearRelationship(

--- a/dbushelper.py
+++ b/dbushelper.py
@@ -483,9 +483,10 @@ class DbusHelper:
                         voltageSum += voltage
                 pathbase = "Cell" if (BATTERY_CELL_DATA_FORMAT & 2) else "Voltages"
                 self._dbusservice["/%s/Sum" % pathbase] = voltageSum
+                max_v = self.battery.get_max_cell_voltage()
+                min_v = self.battery.get_min_cell_voltage()
                 self._dbusservice["/%s/Diff" % pathbase] = (
-                    self.battery.get_max_cell_voltage()
-                    - self.battery.get_min_cell_voltage()
+                    max_v - min_v if max_v is not None and min_v is not None else None
                 )
             except Exception:
                 logger.warning("Cell voltage publish failed for %s", self.battery.port, exc_info=True)


### PR DESCRIPTION
## Summary

- Cell voltages are `None` until the first BLE read completes
- The D-Bus poll fires every 5s, hitting `calcMaxCharge/DischargeCurrentReferringToCellVoltage` and the Diff publish before any cell data arrived
- Added `None` guards matching the existing pattern in the temperature methods

## Test Plan

- [ ] Deploy to Cerbo GX; confirm no TypeError warnings in log during the startup window before first BLE read completes
- [ ] Confirm CCCM/DCCM calculations work normally once cell data arrives

Closes #34

🤖 Generated with [Claude Code](https://claude.ai/claude-code)