### PR TITLE
fix: remove unused BT_SOFT_RESET_TIMEOUT and BT_RECONNECT_TIMEOUT config keys

### DIFF
--- a/default_config.ini
+++ b/default_config.ini
@@ -154,16 +154,6 @@ BT_POLL_INTERVAL = 300
 ; Keeps the fixed polling offset stable across all subsequent cycles.
 BT_CONNECT_STAGGER = 5
 
-; Soft-reset timeout in seconds — resets notification handler state machine
-; when no successful data callback has arrived within this window.
-; 0 to disable. Must be > BT_POLL_INTERVAL.
-BT_SOFT_RESET_TIMEOUT = 60
-
-; Reconnect timeout in seconds — forces BLE disconnect/reconnect when
-; soft reset hasn't restored data flow. 0 to disable.
-; Must be > BT_SOFT_RESET_TIMEOUT.
-BT_RECONNECT_TIMEOUT = 120
-
 ; D-Bus publish interval in milliseconds (how often cached data is pushed to D-Bus)
 DBUS_POLL_INTERVAL = 5000
 


### PR DESCRIPTION
## Summary

- Removes `BT_SOFT_RESET_TIMEOUT` and `BT_RECONNECT_TIMEOUT` from `default_config.ini`
- Neither key is read anywhere in the Python code

Closes #36

🤖 Generated with [Claude Code](https://claude.ai/claude-code)