### PR TITLE
fix: parallel InstalledCapacity wrong when a battery misses startup window

### DIFF
--- a/dbushelper.py
+++ b/dbushelper.py
@@ -370,6 +370,11 @@ class DbusHelper:
         )
         self._dbusservice["/Dc/0/Temperature"] = self.battery.get_temp()
         self._dbusservice["/Capacity"] = self.battery.get_capacity_remain()
+        # Keep InstalledCapacity current — for a parallel aggregate this can
+        # start low if some batteries miss the setup_vedbus() window and must
+        # self-correct once all batteries have connected and provided data.
+        if self.battery.capacity is not None:
+            self._dbusservice["/InstalledCapacity"] = self.battery.capacity
         self._dbusservice["/ConsumedAmphours"] = (
             0
             if self.battery.capacity is None

--- a/jbdbt.py
+++ b/jbdbt.py
@@ -181,10 +181,15 @@ class BleakJbdDev:
 
 			if self.running:
 				if success:
-					logger.info(f'Disconnected {self.address} (read complete, next in {self.interval}s)')
+					sleep_for = self.interval
+					logger.info(f'Disconnected {self.address} (read complete, next in {sleep_for}s)')
 				else:
-					logger.info(f'Disconnected {self.address}')
-				await asyncio.sleep(self.interval)
+					# Before the first successful read, use a short retry so
+					# setup_vedbus() can see all batteries within its 30s window.
+					# After the first read, fall back to the normal poll interval.
+					sleep_for = BT_INIT_RETRY_INTERVAL if self.last_read_time == 0.0 else self.interval
+					logger.info(f'Disconnected {self.address} (failed, retry in {sleep_for}s)')
+				await asyncio.sleep(sleep_for)
 
 	def stop(self):
 		self.running = False


### PR DESCRIPTION
Fixes #40

## Summary

- **`jbdbt.py`**: When a BLE connect fails before the first successful read (`last_read_time == 0.0`), retry after `BT_INIT_RETRY_INTERVAL` (30s) instead of sleeping the full `BT_POLL_INTERVAL` (180s). Normal interval resumes after the first read succeeds. This gives a lagging battery a chance to be seen by the aggregate's `setup_vedbus()` 30s polling window.

- **`dbushelper.py`**: Add `InstalledCapacity` to the `publish_dbus()` update cycle. `ParallelBattery.refresh_data()` already calls `get_settings()` which recomputes `capacity` from all connected batteries each poll, so the value self-corrects within one D-Bus poll interval (5s) of the late battery's first successful read.

## Test plan

- [ ] Deploy to Cerbo GX with 4-battery parallel setup
- [ ] Restart the service and confirm `dbus -y com.victronenergy.battery.parallel /InstalledCapacity GetValue` returns `600.0`
- [ ] Confirm the 180s poll interval is unchanged for batteries that connect successfully
- [ ] Confirm individual batteries still report `150.0` each

🤖 Generated with [Claude Code](https://claude.com/claude-code)