### PR TITLE
Clean shutdown + pre-start HCI reset (closes #42)

### DIFF
--- a/dbus-btbattery.py
+++ b/dbus-btbattery.py
@@ -156,6 +156,21 @@ def main():
 	except KeyboardInterrupt:
 		pass
 
+	# Graceful shutdown: disconnect any in-flight BleakClient so BlueZ
+	# doesn't carry stale GATT operations into the next process lifetime.
+	# Without this, repeated watchdog restarts accumulate BlueZ cruft until
+	# the adapter reports "No powered Bluetooth adapters found" and requires
+	# an HCI reset (see service/run) or a Cerbo reboot to recover.
+	logger.info("Shutting down BLE connections")
+	for batt in batteries:
+		try:
+			batt._ble_dev.shutdown()
+		except Exception:
+			logger.warning(
+				"Shutdown error for %s", batt._ble_dev.address, exc_info=True
+			)
+	logger.info("dbus-btbattery exited cleanly")
+
 
 if __name__ == "__main__":
 	main()

--- a/default_config.ini
+++ b/default_config.ini
@@ -141,6 +141,11 @@ BMS_TYPE =
 ; Connection mode: single, series, parallel
 CONNECTION_MODE = single
 
+; BLE adapter used for battery connections and pre-start reset in service/run.
+; Run `hciconfig` on the Cerbo GX to see available adapters. Leave empty to
+; let bleak pick the default. Typical values: hci0 (internal), hci1 (USB).
+BT_ADAPTER = hci1
+
 ; Bluetooth addresses (comma-separated for multi-battery)
 ; Example: BT_ADDRESSES = 70:3e:97:08:00:62,a4:c1:37:40:89:5e
 BT_ADDRESSES =

--- a/jbdbt.py
+++ b/jbdbt.py
@@ -108,6 +108,11 @@ class BleakJbdDev:
 		self._general_event: asyncio.Event | None = None
 		self._cell_event: asyncio.Event | None = None
 
+		# Active BleakClient during a connect-read-disconnect cycle; None when
+		# idle between cycles. Tracked so shutdown() can cleanly disconnect
+		# any in-flight GATT session before the process exits.
+		self._current_client = None
+
 	def reset(self):
 		"""Reset the notification state machine buffers for a fresh read cycle."""
 		self.last_state = "0000"
@@ -134,7 +139,8 @@ class BleakJbdDev:
 			await asyncio.sleep(self.initial_delay)
 		while self.running:
 			success = False
-			client = BleakClient(self.address)
+			client = BleakClient(self.address, adapter=BT_ADAPTER or None)
+			self._current_client = client
 			logger.info('Connecting ' + self.address)
 			try:
 				# Hold the lock for the entire connect-read-disconnect cycle so
@@ -178,6 +184,8 @@ class BleakJbdDev:
 				logger.info('Connection failed: ' + str(ex))
 			except Exception as ex:
 				logger.info('BLE error: ' + str(ex))
+			finally:
+				self._current_client = None
 
 			if self.running:
 				if success:
@@ -193,6 +201,36 @@ class BleakJbdDev:
 
 	def stop(self):
 		self.running = False
+
+	def shutdown(self, timeout: float = 3.0) -> None:
+		"""Request graceful shutdown: stop looping and disconnect any active
+		BleakClient so BlueZ doesn't carry stale GATT operations into the
+		next process lifetime.
+
+		Safe to call from any thread. Best-effort: swallows all exceptions
+		and returns within ``timeout`` seconds even if the disconnect hangs.
+		"""
+		self.running = False
+		client = self._current_client
+		if client is None:
+			return
+		loop = _ble_loop
+		if loop is None or not loop.is_running():
+			return
+		try:
+			future = asyncio.run_coroutine_threadsafe(
+				self._disconnect_async(client), loop
+			)
+			future.result(timeout=timeout)
+		except Exception:
+			pass
+
+	async def _disconnect_async(self, client) -> None:
+		try:
+			if client.is_connected:
+				await client.disconnect()
+		except Exception:
+			pass
 
 	def addCellDataCallback(self, func):
 		self.cellDataCallback = func

--- a/service/run
+++ b/service/run
@@ -1,5 +1,15 @@
 #!/bin/sh
 exec 2>&1
+
+# Reset the BLE adapter before startup to clear any stale BlueZ state left
+# by a prior unclean exit (e.g. watchdog-triggered kill mid-GATT-cycle).
+# Without this, BlueZ accumulates `[org.bluez.Error.InProgress]` references
+# until the adapter reports "No powered Bluetooth adapters found" to bleak
+# and only a Cerbo reboot recovers. See issue #42.
+BT_ADAPTER=$(python3 -c "import configparser; c=configparser.ConfigParser(); c.read(['/opt/victronenergy/dbus-btbattery/default_config.ini', '/data/dbus-btbattery/config.ini']); print(c.get('DEFAULT', 'BT_ADAPTER', fallback='hci1').strip())" 2>/dev/null || echo "hci1")
+hciconfig "$BT_ADAPTER" reset 2>/dev/null || true
+sleep 2
+
 # Single battery:
 # exec /opt/victronenergy/dbus-btbattery/dbus-btbattery.py 70:3e:97:08:00:62
 # Parallel batteries:

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -1,0 +1,185 @@
+"""Tests for BleakJbdDev.shutdown() and _current_client tracking.
+
+shutdown() gracefully disconnects any active BleakClient before the process
+exits, preventing BlueZ from accumulating stale GATT operations across
+unclean btbattery restart cycles.
+"""
+
+import asyncio
+import os
+import sys
+import threading
+import time
+from unittest.mock import MagicMock
+
+_PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+import jbdbt
+from jbdbt import BleakJbdDev
+
+
+def _run_loop_in_thread():
+    """Start a real asyncio loop in a background thread and install it as
+    jbdbt._ble_loop. Returns (loop, thread, cleanup_fn)."""
+    loop = asyncio.new_event_loop()
+    t = threading.Thread(target=loop.run_forever, daemon=True)
+    t.start()
+
+    async def _make_lock():
+        return asyncio.Lock()
+
+    connect_lock = asyncio.run_coroutine_threadsafe(_make_lock(), loop).result(timeout=1)
+
+    orig_loop = jbdbt._ble_loop
+    orig_lock = jbdbt._ble_connect_lock
+    jbdbt._ble_loop = loop
+    jbdbt._ble_connect_lock = connect_lock
+
+    def cleanup():
+        # Cancel any tasks that are still pending (e.g. a hung disconnect mock)
+        # so we don't get "Task was destroyed but it is pending" warnings.
+        def _cancel_all():
+            for task in asyncio.all_tasks(loop):
+                task.cancel()
+        loop.call_soon_threadsafe(_cancel_all)
+        loop.call_soon_threadsafe(loop.stop)
+        t.join(timeout=2)
+        jbdbt._ble_loop = orig_loop
+        jbdbt._ble_connect_lock = orig_lock
+
+    return loop, cleanup
+
+
+def test_current_client_initialised_to_none():
+    dev = BleakJbdDev("AA:BB:CC:DD:EE:FF")
+    assert dev._current_client is None
+
+
+def test_shutdown_sets_running_false():
+    dev = BleakJbdDev("AA:BB:CC:DD:EE:FF")
+    dev.running = True
+    dev.shutdown(timeout=0.1)
+    assert dev.running is False
+
+
+def test_shutdown_noop_when_no_current_client():
+    """shutdown() must not raise when no BLE cycle is active."""
+    dev = BleakJbdDev("AA:BB:CC:DD:EE:FF")
+    dev.running = True
+    assert dev._current_client is None
+    dev.shutdown(timeout=0.1)
+    assert dev.running is False
+
+
+def test_shutdown_noop_when_loop_never_started():
+    """shutdown() must return promptly if the BLE event loop was never started
+    (e.g. connect() was never called on this device)."""
+    dev = BleakJbdDev("AA:BB:CC:DD:EE:FF")
+    dev._current_client = MagicMock(is_connected=True)
+    dev.running = True
+
+    # Ensure no BLE loop is running for this test.
+    orig_loop = jbdbt._ble_loop
+    jbdbt._ble_loop = None
+    try:
+        start = time.monotonic()
+        dev.shutdown(timeout=0.5)
+        elapsed = time.monotonic() - start
+        assert elapsed < 0.2, f"shutdown() took {elapsed:.3f}s when loop is None"
+        assert dev.running is False
+    finally:
+        jbdbt._ble_loop = orig_loop
+
+
+def test_shutdown_disconnects_active_client():
+    """When a client is active and the BLE loop is running, shutdown() must
+    schedule client.disconnect() and wait for it to complete."""
+    loop, cleanup = _run_loop_in_thread()
+    try:
+        dev = BleakJbdDev("AA:BB:CC:DD:EE:FF")
+
+        disconnect_called = threading.Event()
+
+        async def fake_disconnect():
+            disconnect_called.set()
+
+        mock_client = MagicMock()
+        mock_client.is_connected = True
+        mock_client.disconnect = fake_disconnect
+        dev._current_client = mock_client
+        dev.running = True
+
+        dev.shutdown(timeout=3.0)
+
+        assert dev.running is False
+        assert disconnect_called.is_set(), "disconnect() was not called"
+    finally:
+        cleanup()
+
+
+def test_shutdown_skips_disconnect_when_client_not_connected():
+    """If client.is_connected is False, we should not call disconnect()."""
+    loop, cleanup = _run_loop_in_thread()
+    try:
+        dev = BleakJbdDev("AA:BB:CC:DD:EE:FF")
+
+        disconnect_called = threading.Event()
+
+        async def fake_disconnect():
+            disconnect_called.set()
+
+        mock_client = MagicMock()
+        mock_client.is_connected = False
+        mock_client.disconnect = fake_disconnect
+        dev._current_client = mock_client
+
+        dev.shutdown(timeout=1.0)
+
+        assert not disconnect_called.is_set(), "disconnect() should be skipped when not connected"
+    finally:
+        cleanup()
+
+
+def test_shutdown_honours_timeout_when_disconnect_hangs():
+    """A hanging disconnect() must not block shutdown() longer than the timeout."""
+    loop, cleanup = _run_loop_in_thread()
+    try:
+        dev = BleakJbdDev("AA:BB:CC:DD:EE:FF")
+
+        async def hang_forever():
+            await asyncio.sleep(10)
+
+        mock_client = MagicMock()
+        mock_client.is_connected = True
+        mock_client.disconnect = hang_forever
+        dev._current_client = mock_client
+
+        start = time.monotonic()
+        dev.shutdown(timeout=0.5)
+        elapsed = time.monotonic() - start
+
+        assert elapsed < 2.0, f"shutdown() took {elapsed:.3f}s, timeout was 0.5s"
+    finally:
+        cleanup()
+
+
+def test_shutdown_swallows_disconnect_exception():
+    """shutdown() must not propagate exceptions from disconnect()."""
+    loop, cleanup = _run_loop_in_thread()
+    try:
+        dev = BleakJbdDev("AA:BB:CC:DD:EE:FF")
+
+        async def raise_error():
+            raise RuntimeError("BlueZ is angry")
+
+        mock_client = MagicMock()
+        mock_client.is_connected = True
+        mock_client.disconnect = raise_error
+        dev._current_client = mock_client
+
+        # Must not raise.
+        dev.shutdown(timeout=1.0)
+    finally:
+        cleanup()

--- a/utils.py
+++ b/utils.py
@@ -223,6 +223,7 @@ BMS_TYPE = config["DEFAULT"]["BMS_TYPE"]
 
 # Connection settings
 CONNECTION_MODE = config["DEFAULT"]["CONNECTION_MODE"]
+BT_ADAPTER = config["DEFAULT"]["BT_ADAPTER"].strip()
 BT_ADDRESSES = _get_list_from_config("DEFAULT", "BT_ADDRESSES")
 BT_POLL_INTERVAL = int(config["DEFAULT"]["BT_POLL_INTERVAL"])
 BT_CONNECT_STAGGER = int(config["DEFAULT"]["BT_CONNECT_STAGGER"])


### PR DESCRIPTION
Closes #42

## Summary

- **Graceful BLE shutdown.** `BleakJbdDev` tracks `_current_client` during each connect-read-disconnect cycle; new `shutdown(timeout=3.0)` disconnects any in-flight client before the process exits. `main()` calls it on every battery after `mainloop.run()` returns.
- **Pre-start HCI reset.** `service/run` runs `hciconfig <adapter> reset` before `exec` so every restart starts from a clean BlueZ state, even if the prior process exited uncleanly.
- **BT_ADAPTER config.** New first-class option in `default_config.ini` (default `hci1`). Both `BleakClient(adapter=...)` and the pre-start reset read the same value, so they can't drift.

## Root cause

The BLE watchdog added in #38 recovers from stalled GATT reads by calling `mainloop.quit()`, but `main()` exited the process immediately without cleaning up active `BleakClient`s:

```python
try:
    mainloop.run()
except KeyboardInterrupt:
    pass
```

If the watchdog fired mid-cycle, BlueZ held a stale `[org.bluez.Error.InProgress]` reference across the restart. After enough cycles, the adapter reported `"No powered Bluetooth adapters found"` to bleak despite `hciconfig -a` showing `UP RUNNING`. All 4 batteries dropped off D-Bus, the SmartSolar MPPT raised error **#67 BMS Connection Lost** (DVCC safety trip because systemcalc no longer had CCL/CVL to forward), and the only recovery was a Cerbo reboot.

Reproduced live: `hciconfig hci1 reset` cleared the stuck state and all 4 batteries reconnected within ~3 seconds — proving the wedge was BlueZ userspace state, not the adapter hardware.

## Test plan

- [x] Unit tests (8 new, all passing): `_current_client` initial None, `shutdown()` sets `running=False`, no-op when no client, no-op when event loop never started, disconnects active client, skips disconnect when not connected, honours timeout if disconnect hangs, swallows exceptions from disconnect
- [x] Full pytest suite: 61/61 passing
- [x] Ruff lint clean on `jbdbt.py` and `dbus-btbattery.py`
- [x] Bandit scan: 3 Low-severity B110 findings (try/except/pass) — 1 pre-existing, 2 new — all intentional best-effort cleanup matching project convention
- [ ] Deploy to Cerbo GX and confirm:
  - [ ] btbattery restart no longer wedges the adapter
  - [ ] `svc -t /service/dbus-btbattery` recovers cleanly (no Cerbo reboot needed)
  - [ ] No more error #67 on the SmartSolar after sustained uptime
  - [ ] `/data/dbus-btbattery/config.ini` with `BT_ADAPTER = hci1` correctly overrides the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)