### PR TITLE
Escape-the-wedge: watchdog + retry + shutdown fixes (closes #44)

### DIFF
--- a/dbus-btbattery.py
+++ b/dbus-btbattery.py
@@ -77,16 +77,26 @@ def main():
 	mainloop = gobject.MainLoop()
 
 	if utils.BT_WATCHDOG_TIMEOUT > 0:
+		process_start_time = time.monotonic()
+
 		def watchdog():
 			now = time.monotonic()
 			for batt in batteries:
 				if batt._ble_dev.last_read_time == 0.0:
-					continue
-				elapsed = now - batt._ble_dev.last_read_time
+					# Never read — check against process start instead of
+					# skipping. Without this, a wedge that prevents the first
+					# read after a restart traps the process forever because
+					# the watchdog has no timestamp to compare against.
+					elapsed = now - process_start_time
+					reason = "no reads since startup"
+				else:
+					elapsed = now - batt._ble_dev.last_read_time
+					reason = "no read"
 				if elapsed > utils.BT_WATCHDOG_TIMEOUT:
 					logger.error(
-						"Watchdog: %s has not completed a read in %.0fs, restarting",
+						"Watchdog: %s — %s in %.0fs, restarting",
 						batt._ble_dev.address,
+						reason,
 						elapsed,
 					)
 					mainloop.quit()
@@ -146,6 +156,17 @@ def main():
 						still_pending.append([batt, retry_count])
 			pending.clear()
 			pending.extend(still_pending)
+
+			# If every battery gave up with nothing registered, exit so the
+			# watchdog-driven restart cycle retries with a fresh process and
+			# fresh HCI reset. Without this, a wedge at startup permanently
+			# traps the service with no D-Bus presence even if BLE later
+			# recovers on its own.
+			if len(pending) == 0 and len(active_helpers) == 0:
+				logger.error("All batteries failed initial setup, exiting service")
+				mainloop.quit()
+				return False
+
 			return len(pending) > 0  # False stops the GLib timer
 
 		gobject.timeout_add(utils.BT_INIT_RETRY_INTERVAL * 1000, retry_pending)

--- a/jbdbt.py
+++ b/jbdbt.py
@@ -226,9 +226,14 @@ class BleakJbdDev:
 			pass
 
 	async def _disconnect_async(self, client) -> None:
+		# Call disconnect() unconditionally — bleak tolerates it on a
+		# not-yet-connected client, and it's specifically needed when
+		# connect() is hanging (is_connected == False) so BlueZ gets a
+		# signal to abort the pending GATT operation. Without this the
+		# stale BlueZ state survives the process restart and wedges the
+		# next lifetime's connection attempts.
 		try:
-			if client.is_connected:
-				await client.disconnect()
+			await client.disconnect()
 		except Exception:
 			pass
 

--- a/service/run
+++ b/service/run
@@ -7,8 +7,21 @@ exec 2>&1
 # until the adapter reports "No powered Bluetooth adapters found" to bleak
 # and only a Cerbo reboot recovers. See issue #42.
 BT_ADAPTER=$(python3 -c "import configparser; c=configparser.ConfigParser(); c.read(['/opt/victronenergy/dbus-btbattery/default_config.ini', '/data/dbus-btbattery/config.ini']); print(c.get('DEFAULT', 'BT_ADAPTER', fallback='hci1').strip())" 2>/dev/null || echo "hci1")
-hciconfig "$BT_ADAPTER" reset 2>/dev/null || true
-sleep 2
+
+# Log the reset result so the operator can confirm it ran (and succeeded).
+# Merges stderr into stdout which the service log captures via exec 2>&1 above.
+echo "[run] resetting $BT_ADAPTER..."
+if hciconfig "$BT_ADAPTER" reset 2>&1; then
+    echo "[run] $BT_ADAPTER reset OK"
+else
+    echo "[run] $BT_ADAPTER reset FAILED (rc=$?)"
+fi
+
+# Give bluetoothd time to settle after the reset before bleak starts
+# issuing Connect method calls. A short sleep (e.g. 2s) isn't always
+# enough — BlueZ may still be processing the reset internally and
+# reject or hang new connections. See issue #44.
+sleep 5
 
 # Single battery:
 # exec /opt/victronenergy/dbus-btbattery/dbus-btbattery.py 70:3e:97:08:00:62

--- a/tests/test_retry_pending.py
+++ b/tests/test_retry_pending.py
@@ -1,0 +1,199 @@
+"""Tests for the retry_pending() closure used in dbus-btbattery.py main().
+
+After all retries exhaust, if NO batteries have registered, we call
+mainloop.quit() so the watchdog-driven restart cycle can try again
+with a fresh process (and fresh HCI reset). Without this, a wedge that
+prevents the first connection traps the process in a broken state even
+though the BLE loop itself may recover later.
+"""
+
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+
+class _MockHelper:
+    def __init__(self, succeed=False, port="/test"):
+        self._succeed = succeed
+        self.battery = type("B", (), {"port": port})()
+
+    def setup_vedbus(self):
+        return self._succeed
+
+
+class _MockLoop:
+    def __init__(self):
+        self.quit_called = False
+    def quit(self):
+        self.quit_called = True
+
+
+def _make_retry_pending(pending, active_helpers, mainloop, max_retries=5,
+                        helper_factory=None):
+    """Mirror the retry_pending closure in dbus-btbattery.py main().
+
+    helper_factory(battery) is called for each retry; it returns a
+    helper object with setup_vedbus(). This lets tests control the
+    pass/fail sequence per retry cycle.
+    """
+    import logging
+    logger = logging.getLogger("BluetoothBattery")
+
+    def retry_pending():
+        still_pending = []
+        for batt, retry_count in pending:
+            new_helper = helper_factory(batt)
+            if new_helper.setup_vedbus():
+                active_helpers.append(new_helper)
+                logger.info("Battery %s registered after %d retries",
+                            batt.port, retry_count + 1)
+            else:
+                retry_count += 1
+                if max_retries > 0 and retry_count >= max_retries:
+                    logger.error("Battery %s: giving up after %d retries",
+                                 batt.port, retry_count)
+                else:
+                    still_pending.append([batt, retry_count])
+        pending.clear()
+        pending.extend(still_pending)
+
+        if len(pending) == 0 and len(active_helpers) == 0:
+            # All gave up with nothing registered — exit so the watchdog-driven
+            # restart cycle can retry with a fresh process and HCI reset.
+            logger.error("All batteries failed initial setup, exiting service")
+            mainloop.quit()
+            return False
+
+        return len(pending) > 0
+
+    return retry_pending
+
+
+def _make_battery(port):
+    return type("B", (), {"port": port})()
+
+
+def test_retry_pending_keeps_retrying_when_under_cap():
+    loop = _MockLoop()
+    batt = _make_battery("/btA")
+    pending = [[batt, 0]]
+    active = []
+
+    rp = _make_retry_pending(
+        pending, active, loop,
+        max_retries=5,
+        helper_factory=lambda b: _MockHelper(succeed=False, port=b.port),
+    )
+
+    assert rp() is True   # still has pending, keep timer running
+    assert not loop.quit_called
+    assert pending == [[batt, 1]]
+
+
+def test_retry_pending_registers_on_success():
+    loop = _MockLoop()
+    batt = _make_battery("/btA")
+    pending = [[batt, 2]]
+    active = []
+
+    rp = _make_retry_pending(
+        pending, active, loop,
+        max_retries=5,
+        helper_factory=lambda b: _MockHelper(succeed=True, port=b.port),
+    )
+
+    assert rp() is False   # pending empty AND active non-empty
+    assert len(active) == 1
+    assert not loop.quit_called
+
+
+def test_retry_pending_quits_when_all_give_up_with_none_active():
+    """THE KEY FIX: when all retries exhaust and nothing registered,
+    call mainloop.quit() to trigger a restart."""
+    loop = _MockLoop()
+    batt = _make_battery("/btA")
+    pending = [[batt, 4]]   # one more retry takes it past max=5
+    active = []
+
+    rp = _make_retry_pending(
+        pending, active, loop,
+        max_retries=5,
+        helper_factory=lambda b: _MockHelper(succeed=False, port=b.port),
+    )
+
+    assert rp() is False
+    assert loop.quit_called
+    assert len(pending) == 0
+    assert len(active) == 0
+
+
+def test_retry_pending_does_not_quit_when_partial_success():
+    """When some batteries registered and others gave up, keep running
+    with the partial set — don't force a restart."""
+    loop = _MockLoop()
+    batt_a = _make_battery("/btA")
+    batt_b = _make_battery("/btB")
+
+    # A is already registered (simulate prior success)
+    active = [_MockHelper(succeed=True, port="/btA")]
+    # B is on its last retry and about to give up
+    pending = [[batt_b, 4]]
+
+    rp = _make_retry_pending(
+        pending, active, loop,
+        max_retries=5,
+        helper_factory=lambda b: _MockHelper(succeed=False, port=b.port),
+    )
+
+    result = rp()
+    assert result is False   # pending empty, so timer stops
+    assert not loop.quit_called   # but we don't force a restart
+    assert len(pending) == 0
+    assert len(active) == 1
+
+
+def test_retry_pending_all_batteries_gave_up_multiple_quits():
+    """With multiple batteries all failing, we only quit once all have
+    exhausted their retries AND nothing registered."""
+    loop = _MockLoop()
+    batt_a = _make_battery("/btA")
+    batt_b = _make_battery("/btB")
+    pending = [[batt_a, 4], [batt_b, 2]]   # A at cap-1, B mid-way
+    active = []
+
+    rp = _make_retry_pending(
+        pending, active, loop,
+        max_retries=5,
+        helper_factory=lambda b: _MockHelper(succeed=False, port=b.port),
+    )
+
+    # First call: A gives up, B still has retries left
+    assert rp() is True
+    assert not loop.quit_called
+    assert len(pending) == 1   # B still pending
+
+    # Keep calling until B gives up too
+    for _ in range(3):
+        if rp() is False:
+            break
+
+    # Once B exhausts and active is still empty, quit fires
+    assert loop.quit_called
+
+
+def test_retry_pending_infinite_retries_never_give_up():
+    """With max_retries=0 (infinite), nothing ever gives up so quit is
+    never called from retry_pending regardless of how many failures."""
+    loop = _MockLoop()
+    batt = _make_battery("/btA")
+    pending = [[batt, 99]]
+    active = []
+
+    rp = _make_retry_pending(
+        pending, active, loop,
+        max_retries=0,   # infinite
+        helper_factory=lambda b: _MockHelper(succeed=False, port=b.port),
+    )
+
+    assert rp() is True   # still pending
+    assert not loop.quit_called
+    assert pending == [[batt, 100]]

--- a/tests/test_shutdown.py
+++ b/tests/test_shutdown.py
@@ -119,8 +119,11 @@ def test_shutdown_disconnects_active_client():
         cleanup()
 
 
-def test_shutdown_skips_disconnect_when_client_not_connected():
-    """If client.is_connected is False, we should not call disconnect()."""
+def test_shutdown_calls_disconnect_even_when_not_connected():
+    """A hung connect() holds is_connected=False while a GATT operation is
+    still pending in BlueZ. We must call disconnect() anyway to signal
+    BlueZ to abort the pending op — otherwise the stale GATT state
+    survives into the next process lifetime and re-wedges the adapter."""
     loop, cleanup = _run_loop_in_thread()
     try:
         dev = BleakJbdDev("AA:BB:CC:DD:EE:FF")
@@ -131,13 +134,14 @@ def test_shutdown_skips_disconnect_when_client_not_connected():
             disconnect_called.set()
 
         mock_client = MagicMock()
-        mock_client.is_connected = False
+        mock_client.is_connected = False   # mid-connect, not yet connected
         mock_client.disconnect = fake_disconnect
         dev._current_client = mock_client
 
         dev.shutdown(timeout=1.0)
 
-        assert not disconnect_called.is_set(), "disconnect() should be skipped when not connected"
+        assert disconnect_called.is_set(), \
+            "disconnect() must be called even on hung-connect clients"
     finally:
         cleanup()
 

--- a/tests/test_watchdog.py
+++ b/tests/test_watchdog.py
@@ -11,8 +11,8 @@ class _MockDev:
 
 
 class _MockBatt:
-    def __init__(self, last_read_time):
-        self._ble_dev = _MockDev(last_read_time)
+    def __init__(self, last_read_time, address="AA:BB:CC:DD:EE:FF"):
+        self._ble_dev = _MockDev(last_read_time, address)
 
 
 class _MockLoop:
@@ -22,20 +22,28 @@ class _MockLoop:
         self.quit_called = True
 
 
-def _make_watchdog(batteries, mainloop):
-    """Mirror the exact closure used in dbus-btbattery.py main()."""
+def _make_watchdog(batteries, mainloop, process_start_time):
+    """Mirror the exact closure used in dbus-btbattery.py main().
+
+    Batteries that have never successfully read (last_read_time == 0.0)
+    are checked against process_start_time instead of being skipped.
+    This ensures the service can escape a wedge where the first read
+    never completes after a restart.
+    """
     def watchdog():
         now = time.monotonic()
         for batt in batteries:
             if batt._ble_dev.last_read_time == 0.0:
-                continue
-            elapsed = now - batt._ble_dev.last_read_time
+                elapsed = now - process_start_time
+                reason = "no reads since startup"
+            else:
+                elapsed = now - batt._ble_dev.last_read_time
+                reason = "no read"
             if elapsed > utils.BT_WATCHDOG_TIMEOUT:
                 import logging
                 logging.getLogger("BluetoothBattery").error(
-                    "Watchdog: %s has not completed a read in %.0fs, restarting",
-                    batt._ble_dev.address,
-                    elapsed,
+                    "Watchdog: %s — %s in %.0fs, restarting",
+                    batt._ble_dev.address, reason, elapsed,
                 )
                 mainloop.quit()
                 return False
@@ -43,18 +51,10 @@ def _make_watchdog(batteries, mainloop):
     return watchdog
 
 
-def test_watchdog_skips_battery_never_read():
-    loop = _MockLoop()
-    batt = _MockBatt(0.0)
-    wd = _make_watchdog([batt], loop)
-    assert wd() is True
-    assert not loop.quit_called
-
-
 def test_watchdog_no_trigger_when_recent():
     loop = _MockLoop()
     batt = _MockBatt(time.monotonic())
-    wd = _make_watchdog([batt], loop)
+    wd = _make_watchdog([batt], loop, time.monotonic())
     assert wd() is True
     assert not loop.quit_called
 
@@ -63,7 +63,7 @@ def test_watchdog_triggers_and_quits_when_stale():
     loop = _MockLoop()
     stale_time = time.monotonic() - utils.BT_WATCHDOG_TIMEOUT - 1
     batt = _MockBatt(stale_time)
-    wd = _make_watchdog([batt], loop)
+    wd = _make_watchdog([batt], loop, time.monotonic())
     result = wd()
     assert result is False   # False stops the GLib timer
     assert loop.quit_called
@@ -74,6 +74,40 @@ def test_watchdog_first_stale_battery_stops_scan():
     loop = _MockLoop()
     stale = _MockBatt(time.monotonic() - utils.BT_WATCHDOG_TIMEOUT - 1)
     fresh = _MockBatt(time.monotonic())
-    wd = _make_watchdog([stale, fresh], loop)
+    wd = _make_watchdog([stale, fresh], loop, time.monotonic())
+    assert wd() is False
+    assert loop.quit_called
+
+
+def test_watchdog_never_read_recent_startup_does_not_trigger():
+    """A battery that has never read should NOT trigger the watchdog while
+    the process is still within its grace period (process started recently)."""
+    loop = _MockLoop()
+    batt = _MockBatt(0.0)
+    wd = _make_watchdog([batt], loop, time.monotonic())   # just started
+    assert wd() is True
+    assert not loop.quit_called
+
+
+def test_watchdog_never_read_old_startup_triggers():
+    """A battery that has never read MUST trigger the watchdog if the
+    process has been running longer than BT_WATCHDOG_TIMEOUT — otherwise
+    a wedge that prevents the first read traps the process forever."""
+    loop = _MockLoop()
+    batt = _MockBatt(0.0)
+    old_start = time.monotonic() - utils.BT_WATCHDOG_TIMEOUT - 1
+    wd = _make_watchdog([batt], loop, old_start)
+    assert wd() is False
+    assert loop.quit_called
+
+
+def test_watchdog_never_read_triggered_among_mixed_batteries():
+    """One never-read battery past the timeout should trigger even when
+    other batteries are reading normally."""
+    loop = _MockLoop()
+    fresh = _MockBatt(time.monotonic(), address="AA:AA:AA:AA:AA:AA")
+    never = _MockBatt(0.0, address="BB:BB:BB:BB:BB:BB")
+    old_start = time.monotonic() - utils.BT_WATCHDOG_TIMEOUT - 1
+    wd = _make_watchdog([fresh, never], loop, old_start)
     assert wd() is False
     assert loop.quit_called


### PR DESCRIPTION
Closes #44

Follow-up to #43 (which fixed the primary BlueZ-wedge symptom) — the log from 24h of running the merged fix revealed a **secondary failure cascade** that leaves the process permanently broken once a restart fails to recover BLE.

## What's happening

1. BlueZ wedges mid-operation (4× `Connecting` with zero `Connected` / zero errors)
2. Watchdog fires, clean shutdown + HCI reset run, process restarts ✓
3. Fresh process: all 4 `BleakClient.connect()` calls hang again
4. `setup_vedbus()` retries 5 times, then **gives up permanently per battery**
5. `retry_pending()` removes gave-up batteries from `pending`
6. **Watchdog never fires again** — `last_read_time == 0.0` for every battery was treated as "skip"
7. Service sits wedged for 20+ hours, no D-Bus registration, no recovery

Even a manual `hciconfig hci1 reset` after this state only recovers the BLE reads — retry_pending has already dropped the batteries, so D-Bus registration never happens.

## Five fixes

**1. Watchdog never-read gap (highest impact).** Introduce `process_start_time` at startup. For batteries with `last_read_time == 0.0`, check elapsed since process start instead of skipping. A wedge that prevents the first read after a restart now triggers another restart after `BT_WATCHDOG_TIMEOUT` — so the service iterates through restarts until it escapes, instead of getting trapped after one bad restart.

**2. retry_pending exits on total failure.** When every battery exhausts retries AND `active_helpers` is empty, call `mainloop.quit()` so the supervise-restart cycle gets another attempt (with a fresh HCI reset).

**3. `_disconnect_async()` unconditional.** Remove the `is_connected` guard — bleak tolerates `disconnect()` on a not-yet-connected client, and it's specifically what signals BlueZ to abort a hung `Connect` method call. Without this, stale BlueZ GATT state survives the process restart.

**4. `service/run` logs reset result.** Explicit `[run] hci1 reset OK/FAILED (rc=N)` lines in the service log. Previously the command was `hciconfig "$BT_ADAPTER" reset 2>/dev/null || true` — zero evidence in the log that it even ran.

**5. `sleep 5` after reset (was 2).** Gives `bluetoothd` more time to settle before bleak issues its first Connect. Cheap, easy to revert.

## Test plan

- [x] Full pytest suite: 69/69 passing (8 new watchdog + retry tests)
- [x] New tests/test_retry_pending.py with 6 cases (under-cap, success, total-failure-quits, partial-success-no-quit, multi-battery giveup cascade, infinite retries)
- [x] Updated tests/test_watchdog.py — 3 new cases for the never-read-from-startup path
- [x] Updated tests/test_shutdown.py — `test_shutdown_calls_disconnect_even_when_not_connected` (previously tested the opposite behavior)
- [x] Ruff lint: clean on jbdbt.py and dbus-btbattery.py
- [x] Bandit: same 3 B110 findings as before (pre-existing + shutdown try/except/pass) — all intentional
- [ ] Deploy to Cerbo and confirm:
  - [ ] `[run] hci1 reset OK` appears in log on each service start
  - [ ] If wedge recurs, watchdog now fires a second time after `BT_WATCHDOG_TIMEOUT` (900s)
  - [ ] Service eventually escapes via restart cycles rather than sitting dead

🤖 Generated with [Claude Code](https://claude.com/claude-code)