### PR TITLE
Pin BLE adapter by MAC address — stable across boots (closes #46)

### DIFF
--- a/default_config.ini
+++ b/default_config.ini
@@ -141,10 +141,16 @@ BMS_TYPE =
 ; Connection mode: single, series, parallel
 CONNECTION_MODE = single
 
-; BLE adapter used for battery connections and pre-start reset in service/run.
-; Run `hciconfig` on the Cerbo GX to see available adapters. Leave empty to
-; let bleak pick the default. Typical values: hci0 (internal), hci1 (USB).
-BT_ADAPTER = hci1
+; BLE adapter selection. Two ways to pin the adapter, in precedence order:
+;   BT_ADAPTER_MAC = AA:BB:CC:DD:EE:FF  — recommended. Resolves to hciN at
+;       startup by matching BD Address. Stable across reboots (hciN numbers
+;       can swap depending on USB enumeration order).
+;   BT_ADAPTER = hciN                    — legacy. Pins by current kernel name.
+;       Fragile: will break if enumeration order changes between boots.
+; Leave both empty to let bleak pick the default adapter.
+; Run `hciconfig -a` on the Cerbo GX to see your adapter's BD Address.
+BT_ADAPTER_MAC =
+BT_ADAPTER =
 
 ; Bluetooth addresses (comma-separated for multi-battery)
 ; Example: BT_ADDRESSES = 70:3e:97:08:00:62,a4:c1:37:40:89:5e

--- a/service/run
+++ b/service/run
@@ -1,27 +1,66 @@
 #!/bin/sh
 exec 2>&1
 
-# Reset the BLE adapter before startup to clear any stale BlueZ state left
-# by a prior unclean exit (e.g. watchdog-triggered kill mid-GATT-cycle).
-# Without this, BlueZ accumulates `[org.bluez.Error.InProgress]` references
-# until the adapter reports "No powered Bluetooth adapters found" to bleak
-# and only a Cerbo reboot recovers. See issue #42.
-BT_ADAPTER=$(python3 -c "import configparser; c=configparser.ConfigParser(); c.read(['/opt/victronenergy/dbus-btbattery/default_config.ini', '/data/dbus-btbattery/config.ini']); print(c.get('DEFAULT', 'BT_ADAPTER', fallback='hci1').strip())" 2>/dev/null || echo "hci1")
+# Resolve the BLE adapter for the pre-start reset AND for bleak:
+#   BT_ADAPTER_MAC (recommended) — resolve MAC → hciN at startup. Stable
+#       across reboots; hciN numbers swap on kernel enumeration changes.
+#   BT_ADAPTER (legacy) — pin by name directly.
+#   Neither set → skip reset; bleak uses BlueZ default.
+# See issues #42, #44, #46 for background.
 
-# Log the reset result so the operator can confirm it ran (and succeeded).
-# Merges stderr into stdout which the service log captures via exec 2>&1 above.
-echo "[run] resetting $BT_ADAPTER..."
-if hciconfig "$BT_ADAPTER" reset 2>&1; then
-    echo "[run] $BT_ADAPTER reset OK"
-else
-    echo "[run] $BT_ADAPTER reset FAILED (rc=$?)"
+_config_value() {
+    python3 -c "import configparser; c=configparser.ConfigParser(); c.read(['/opt/victronenergy/dbus-btbattery/default_config.ini', '/data/dbus-btbattery/config.ini']); print(c.get('DEFAULT', '$1', fallback='').strip())" 2>/dev/null
+}
+
+BT_ADAPTER_MAC=$(_config_value BT_ADAPTER_MAC)
+BT_ADAPTER=$(_config_value BT_ADAPTER)
+
+# If a MAC is configured, wait up to 30s for the adapter to enumerate and
+# resolve the current hciN name by matching BD Address. USB BT dongles can
+# take 10-20s to enumerate after Venus OS starts services.
+if [ -n "$BT_ADAPTER_MAC" ]; then
+    mac_upper=$(echo "$BT_ADAPTER_MAC" | tr 'a-f' 'A-F')
+    echo "[run] waiting for adapter with MAC $mac_upper..."
+    i=0
+    resolved=""
+    while [ $i -lt 30 ]; do
+        resolved=$(hciconfig -a 2>/dev/null | awk -v mac="$mac_upper" '
+            /^hci[0-9]+:/       { n=$1; sub(":","",n) }
+            /BD Address:/       { if (toupper($3) == mac) { print n; exit } }
+        ')
+        if [ -n "$resolved" ]; then
+            BT_ADAPTER="$resolved"
+            echo "[run] resolved MAC $mac_upper to $BT_ADAPTER after ${i}s"
+            break
+        fi
+        sleep 2
+        i=$((i + 2))
+    done
+    if [ -z "$resolved" ]; then
+        echo "[run] WARN: MAC $mac_upper not found after ${i}s (falling back to BT_ADAPTER='$BT_ADAPTER' if set)"
+    fi
 fi
 
-# Give bluetoothd time to settle after the reset before bleak starts
-# issuing Connect method calls. A short sleep (e.g. 2s) isn't always
-# enough — BlueZ may still be processing the reset internally and
-# reject or hang new connections. See issue #44.
+# Reset the adapter to clear any stale BlueZ state from a prior unclean exit.
+if [ -n "$BT_ADAPTER" ]; then
+    echo "[run] resetting $BT_ADAPTER..."
+    if hciconfig "$BT_ADAPTER" reset 2>&1; then
+        echo "[run] $BT_ADAPTER reset OK"
+    else
+        echo "[run] $BT_ADAPTER reset FAILED (rc=$?)"
+    fi
+else
+    echo "[run] no adapter configured/resolved; skipping reset (bleak will use default)"
+fi
+
+# Give bluetoothd time to settle after the reset before bleak starts issuing
+# Connect method calls. A short sleep isn't always enough — BlueZ may still
+# be processing the reset internally. See issue #44.
 sleep 5
+
+# Export the resolved adapter so the Python process uses the same hciN
+# name we just reset (utils.py reads BT_ADAPTER from env first).
+export BT_ADAPTER
 
 # Single battery:
 # exec /opt/victronenergy/dbus-btbattery/dbus-btbattery.py 70:3e:97:08:00:62

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,3 +25,49 @@ def test_BT_CONNECT_TIMEOUT_is_positive_int():
 def test_BT_WATCHDOG_TIMEOUT_is_non_negative_int():
     assert isinstance(utils.BT_WATCHDOG_TIMEOUT, int)
     assert utils.BT_WATCHDOG_TIMEOUT >= 0
+
+
+def test_BT_ADAPTER_env_var_overrides_config():
+    """service/run resolves BT_ADAPTER_MAC to an hciN name and exports it
+    via env. The Python process must use the env value, not the config
+    value, so both halves of the service stay in sync."""
+    import importlib
+    old_env = os.environ.get("BT_ADAPTER")
+    try:
+        os.environ["BT_ADAPTER"] = "hci7"
+        # Reimport utils so BT_ADAPTER is re-evaluated with the env set.
+        importlib.reload(utils)
+        assert utils.BT_ADAPTER == "hci7"
+    finally:
+        if old_env is None:
+            os.environ.pop("BT_ADAPTER", None)
+        else:
+            os.environ["BT_ADAPTER"] = old_env
+        importlib.reload(utils)
+
+
+def test_BT_ADAPTER_empty_env_falls_back_to_config():
+    """An empty BT_ADAPTER env var must not mask the config value — shell
+    exports the env even when the MAC didn't resolve, and we want the
+    config fallback path to still work."""
+    import importlib
+    old_env = os.environ.get("BT_ADAPTER")
+    try:
+        os.environ["BT_ADAPTER"] = ""
+        importlib.reload(utils)
+        # Falls back to config value (which defaults to '' in default_config.ini).
+        assert utils.BT_ADAPTER == ""
+    finally:
+        if old_env is None:
+            os.environ.pop("BT_ADAPTER", None)
+        else:
+            os.environ["BT_ADAPTER"] = old_env
+        importlib.reload(utils)
+
+
+def test_BT_ADAPTER_MAC_exposed_from_config():
+    """BT_ADAPTER_MAC is exposed on utils for diagnostics — runtime
+    resolution happens in service/run, but utils should reflect what
+    was configured for logging/debugging."""
+    assert hasattr(utils, "BT_ADAPTER_MAC")
+    assert isinstance(utils.BT_ADAPTER_MAC, str)

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+import os
 
 import configparser
 from pathlib import Path
@@ -223,7 +224,14 @@ BMS_TYPE = config["DEFAULT"]["BMS_TYPE"]
 
 # Connection settings
 CONNECTION_MODE = config["DEFAULT"]["CONNECTION_MODE"]
-BT_ADAPTER = config["DEFAULT"]["BT_ADAPTER"].strip()
+# BT_ADAPTER: service/run resolves BT_ADAPTER_MAC to an hciN name and exports
+# it via env var; env takes precedence over the config value so the Python
+# process uses the same adapter the shell reset. Empty → bleak default.
+BT_ADAPTER = (
+    os.environ.get("BT_ADAPTER")
+    or config["DEFAULT"].get("BT_ADAPTER", "")
+).strip()
+BT_ADAPTER_MAC = config["DEFAULT"].get("BT_ADAPTER_MAC", "").strip()
 BT_ADDRESSES = _get_list_from_config("DEFAULT", "BT_ADDRESSES")
 BT_POLL_INTERVAL = int(config["DEFAULT"]["BT_POLL_INTERVAL"])
 BT_CONNECT_STAGGER = int(config["DEFAULT"]["BT_CONNECT_STAGGER"])


### PR DESCRIPTION
Closes #46

## Summary

- New `BT_ADAPTER_MAC` config option — resolves a hardware MAC (BD Address) to the current `hciN` name at startup.
- `service/run` waits up to 30s for the adapter to enumerate (handles the boot race where USB BT dongles take 10–20s to come up).
- Resolved name is exported to the Python process via env var so shell and Python use the same adapter.
- Legacy `BT_ADAPTER = hciN` still works as a fallback.

## Why

The \`hciN\` numbering is determined by kernel/USB enumeration order at boot, not by hardware. Observed:

    Boot A:  hci0 = UART Broadcom (DOWN)      hci1 = USB Realtek (UP)
    Boot B:  hci0 = USB Realtek (UP)          hci1 = UART Broadcom (DOWN)

After #43 we hardcoded `BT_ADAPTER = hci1`. On Boot B this targeted the dead UART adapter:

    [run] resetting hci1...
    Can't init device hci1: Connection timed out (110)
    [run] hci1 reset FAILED (rc=1)
    Connection failed: adapter 'hci1' not found   (×4 batteries)

MAC is the only stable identifier for a specific physical adapter.

## User config

Add to `/data/dbus-btbattery/config.ini`:

    BT_ADAPTER_MAC = 10:BB:F3:81:0F:77

(Replace with your dongle's BD Address from `hciconfig -a`.)

## Test plan

- [x] Full pytest suite: 72/72 passing
- [x] 3 new test_utils.py cases: env-var override, empty-env fallback, BT_ADAPTER_MAC exposure
- [x] Ruff lint clean on changed files
- [ ] Deploy to Cerbo and confirm:
  - [ ] `[run] resolved MAC 10:BB:F3:81:0F:77 to hci0` or similar appears after reboot
  - [ ] Batteries register regardless of whether USB comes up as hci0 or hci1
  - [ ] Reboot 2–3 times to verify stability across enumeration flips

🤖 Generated with [Claude Code](https://claude.com/claude-code)