### PR TITLE
Re-apply index stagger on retry (closes #48)

### DIFF
--- a/jbdbt.py
+++ b/jbdbt.py
@@ -188,19 +188,33 @@ class BleakJbdDev:
 				self._current_client = None
 
 			if self.running:
+				sleep_for = self._next_sleep(success)
 				if success:
-					sleep_for = self.interval
 					logger.info(f'Disconnected {self.address} (read complete, next in {sleep_for}s)')
 				else:
-					# Before the first successful read, use a short retry so
-					# setup_vedbus() can see all batteries within its 30s window.
-					# After the first read, fall back to the normal poll interval.
-					sleep_for = BT_INIT_RETRY_INTERVAL if self.last_read_time == 0.0 else self.interval
 					logger.info(f'Disconnected {self.address} (failed, retry in {sleep_for}s)')
 				await asyncio.sleep(sleep_for)
 
 	def stop(self):
 		self.running = False
+
+	def _next_sleep(self, success: bool) -> float:
+		"""Seconds to sleep after a read cycle.
+
+		On failure, add self.initial_delay (index * BT_CONNECT_STAGGER) to
+		re-establish the startup stagger. Without this, batteries that
+		fail simultaneously (e.g. during a BlueZ wedge) also retry
+		simultaneously — losing the time-offset that kept concurrent GATT
+		traffic manageable. See issue #48.
+		"""
+		if success:
+			return self.interval
+		# Before the first successful read, use the shorter init-retry
+		# interval so setup_vedbus() can see all batteries within its
+		# bounded wait. After the first read, fall back to the normal
+		# poll interval.
+		base = BT_INIT_RETRY_INTERVAL if self.last_read_time == 0.0 else self.interval
+		return base + self.initial_delay
 
 	def shutdown(self, timeout: float = 3.0) -> None:
 		"""Request graceful shutdown: stop looping and disconnect any active

--- a/tests/test_next_sleep.py
+++ b/tests/test_next_sleep.py
@@ -1,0 +1,65 @@
+"""Tests for BleakJbdDev._next_sleep() — the sleep-between-cycles calculator.
+
+On failure, we add self.initial_delay to the base sleep so the index-based
+stagger set at startup is re-established after simultaneous failures.
+Without this, all batteries retry at the same absolute time after a wedge
+and compound BlueZ contention. See issue #48.
+"""
+
+import os
+import sys
+
+_PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, _PROJECT_ROOT)
+
+import jbdbt
+from jbdbt import BleakJbdDev
+
+
+def _make_dev(initial_delay=0.0, last_read_time=0.0):
+    dev = BleakJbdDev("AA:BB:CC:DD:EE:FF")
+    dev.initial_delay = initial_delay
+    dev.last_read_time = last_read_time
+    return dev
+
+
+def test_success_returns_interval():
+    """On a successful read, sleep exactly BT_POLL_INTERVAL — no stagger
+    addition (stagger is only needed on failure clusters)."""
+    dev = _make_dev(initial_delay=15, last_read_time=1000.0)
+    assert dev._next_sleep(success=True) == dev.interval
+
+
+def test_failure_before_first_read_adds_stagger():
+    """Before the first successful read, failure uses the shorter
+    BT_INIT_RETRY_INTERVAL as base — plus the stagger."""
+    dev = _make_dev(initial_delay=30, last_read_time=0.0)
+    assert dev._next_sleep(success=False) == jbdbt.BT_INIT_RETRY_INTERVAL + 30
+
+
+def test_failure_after_first_read_adds_stagger():
+    """After at least one successful read, failure uses BT_POLL_INTERVAL
+    as base (same as success path would) — plus the stagger."""
+    dev = _make_dev(initial_delay=30, last_read_time=1000.0)
+    assert dev._next_sleep(success=False) == dev.interval + 30
+
+
+def test_failure_with_zero_initial_delay_no_extra_stagger():
+    """Battery 0 has initial_delay=0 and should get no extra stagger —
+    it's the reference point that other batteries stagger behind."""
+    dev = _make_dev(initial_delay=0, last_read_time=0.0)
+    assert dev._next_sleep(success=False) == jbdbt.BT_INIT_RETRY_INTERVAL
+
+
+def test_failure_with_zero_delay_after_read_still_uses_interval():
+    dev = _make_dev(initial_delay=0, last_read_time=1000.0)
+    assert dev._next_sleep(success=False) == dev.interval
+
+
+def test_success_ignores_initial_delay():
+    """Success path is stagger-independent — the batteries' natural
+    interval-based timing keeps them spread out once they're cycling."""
+    dev_a = _make_dev(initial_delay=0, last_read_time=1000.0)
+    dev_b = _make_dev(initial_delay=30, last_read_time=1000.0)
+    assert dev_a._next_sleep(success=True) == dev_b._next_sleep(success=True)


### PR DESCRIPTION
Closes #48

## Summary

`initial_delay` was applied one-time at process startup, so batteries that failed simultaneously (BlueZ wedge, adapter reset, etc.) also retried simultaneously — losing the time-offset that kept concurrent GATT traffic manageable.

On failure, now add `self.initial_delay` to the retry sleep so battery N retries at `T+base+N*stagger` instead of all at `T+base`.

## Changes

- Extract sleep calculation into `BleakJbdDev._next_sleep(success)` — a pure method, testable without running the async loop.
- On failure, `sleep_for = base + self.initial_delay` (success path unchanged).
- Log message format preserved: `(failed, retry in Ns)` / `(read complete, next in Ns)`.

## Behaviour example

With 4 batteries (stagger=15s, retry_interval=60s), all failing at T=0:

    Before:  all 4 retry at T=60
    After:   battery 0 → T=60
             battery 1 → T=75
             battery 2 → T=90
             battery 3 → T=105

## Test plan

- [x] `pytest`: 78/78 passing
- [x] 6 new `test_next_sleep.py` cases (success=interval, failure-pre-first-read, failure-post-first-read, zero-delay-no-extra-stagger, success-ignores-delay)
- [x] Ruff lint clean on changed files
- [ ] Deploy to Cerbo; confirm post-wedge recovery shows `Connecting` messages spread ~15s apart instead of simultaneous

🤖 Generated with [Claude Code](https://claude.com/claude-code)